### PR TITLE
Concurrent Compilation and Test Window

### DIFF
--- a/BRDFA_Engine/src/brdfa_engine.hpp
+++ b/BRDFA_Engine/src/brdfa_engine.hpp
@@ -12,7 +12,7 @@
 #include <queue>
 #include <vector>
 #include <thread>
-
+#include <future>
 #include "brdfa_structs.hpp"
 
 
@@ -91,7 +91,7 @@ namespace brdfa {
 		const uint8_t									MAX_FRAMES_IN_FLIGHT = 2;
 
 		std::vector<std::thread>						compilationPool;				// Holds all the threads that are being used to compile the glsl at the moment.
-
+		std::vector<std::future<bool>>					futurePool;						// Another threading utility for helping us create threads that return values
 
 	public:
 		BRDFA_Engine(const BRDFAEngineConfiguration& conf)

--- a/BRDFA_Engine/src/brdfa_engine.hpp
+++ b/BRDFA_Engine/src/brdfa_engine.hpp
@@ -129,6 +129,9 @@ namespace brdfa {
 
 
 	private:
+		//void threadAddSpirv(std::string cacheFileName, BRDF_Panel lp);
+		//void threadCompileGLSL(std::string concat, BRDF_Panel lp);
+
 		void drawUI_objects();
 		void drawUI_camera();
 		void drawUI_editorBRDF();

--- a/BRDFA_Engine/src/brdfa_functions.hpp
+++ b/BRDFA_Engine/src/brdfa_functions.hpp
@@ -151,5 +151,20 @@ namespace brdfa {
 
 
 
+    void threadAddSpirv(const std::string& cacheFileName, BRDF_Panel lp, std::unordered_map<std::string, BRDF_Panel>* loadedBRDFs)
+    {
+        std::vector<char> frag_spirv = readFile(cacheFileName);
+        lp.latest_spir_v = frag_spirv;
+        loadedBRDFs -> insert({ lp.brdfName, lp });
+        printf("[INFO]: ReadFile thread completed: BRDF (%s) \n", lp.brdfName.c_str());
+    }
+
+
+    void threadCompileGLSL(const std::string& concat, BRDF_Panel lp, std::unordered_map<std::string, BRDF_Panel>* loadedBRDFs)
+    {
+        lp.latest_spir_v = compileShader(concat, false, "FragmentSHader");;
+        loadedBRDFs->insert({ lp.brdfName, lp });
+        printf("[INFO]: compileShader thread completed: BRDF (%s) \n", lp.brdfName.c_str());
+    }
   
 }

--- a/BRDFA_Engine/src/brdfa_functions.hpp
+++ b/BRDFA_Engine/src/brdfa_functions.hpp
@@ -160,11 +160,24 @@ namespace brdfa {
     }
 
 
-    void threadCompileGLSL(const std::string& concat, BRDF_Panel lp, std::unordered_map<std::string, BRDF_Panel>* loadedBRDFs)
+    void threadCompileGLSL(const std::string& concat, BRDF_Panel& lp, std::unordered_map<std::string, BRDF_Panel>* loadedBRDFs, bool testing = false)
     {
-        lp.latest_spir_v = compileShader(concat, false, "FragmentSHader");;
-        loadedBRDFs->insert({ lp.brdfName, lp });
-        printf("[INFO]: compileShader thread completed: BRDF (%s) \n", lp.brdfName.c_str());
+        try {
+            std::vector<char> frag_spir = compileShader(concat, false,  lp.brdfName);
+            lp.latest_spir_v = frag_spir;
+            lp.tested = true;
+            lp.log_e = "";
+            if (!testing) loadedBRDFs->insert({ lp.brdfName, lp });
+            printf("[INFO]: compileShader thread completed: BRDF (%s) \n", lp.brdfName.c_str());
+        }
+        catch (const std::exception& exp) {
+            std::cout << exp.what() << std::endl;
+            lp.log_e = exp.what();
+        }
+
+        //lp.latest_spir_v = compileShader(concat, false, "FragmentSHader");;
+        //loadedBRDFs->insert({ lp.brdfName, lp });
+        //printf("[INFO]: compileShader thread completed: BRDF (%s) \n", lp.brdfName.c_str());
     }
   
 }

--- a/BRDFA_Engine/src/brdfa_structs.hpp
+++ b/BRDFA_Engine/src/brdfa_structs.hpp
@@ -497,6 +497,7 @@ namespace brdfa {
         std::vector<char>       latest_spir_v;
         std::string             log_e = "";            // Holds the log of the last compilation
         bool                    tested = false;
+        bool                    requireTest = false;
     };
 
     

--- a/BRDFA_Engine/src/main.cpp
+++ b/BRDFA_Engine/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
     brdfa::BRDFAEngineConfiguration conf;
     conf.height = WINDOW_HEIGHT;
     conf.width = static_cast<uint16_t>(WINDOW_HEIGHT / (9.0 / 16.0));
-    conf.hot_load = true;
+    conf.hot_load = false;
     conf.no_cache_load = false;
     for (int i = 0; i < argc; i++) {
         conf.hot_load = (strcmp(argv[i], "--hot-load") == 0) ? true : conf.hot_load;


### PR DESCRIPTION
Implemented 2 thread pool utilities in the engine. One for threads with return types and the other for bare threading. When the engine starts (loadPipeline()) is called, the shaders will be compiled and loaded asynchronously. Furthermore, I also went a bit further and implemented a Test-Window that you can test the whole engine with one click. Currently we are only testing the compilation of the BRDFs and show the test result in a new window (Test Result).